### PR TITLE
Updated binutils to 2.26 and gcc to 5.3.0

### DIFF
--- a/sweb-binutils.rb
+++ b/sweb-binutils.rb
@@ -1,14 +1,14 @@
 class SwebBinutils < Formula
   desc "FSF Binutils for native development"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
-  url "http://ftpmirror.gnu.org/binutils/binutils-2.25.1.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.gz"
-  sha256 "82a40a37b13a12facb36ac7e87846475a1d80f2e63467b1b8d63ec8b6a2b63fc"
+  url "http://ftpmirror.gnu.org/binutils/binutils-2.26.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.26.tar.gz"
+  sha256 "9615feddaeedc214d1a1ecd77b6697449c952eab69d79ab2125ea050e944bcc1"
 
-  bottle do
-    root_url "https://icg.tugraz.at/~skiba/homebrew"
-    sha256 "741cf4ffd83253601846286fbe2f77bf70a79f264f869fafce8ab0253e2e003a" => :el_capitan
-  end
+#  bottle do
+#    root_url "https://icg.tugraz.at/~skiba/homebrew"
+#    sha256 "741cf4ffd83253601846286fbe2f77bf70a79f264f869fafce8ab0253e2e003a" => :el_capitan
+#  end
 
   def arch
     if Hardware::CPU.type == :intel

--- a/sweb-gcc.rb
+++ b/sweb-gcc.rb
@@ -1,14 +1,14 @@
 class SwebGcc < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org"
-  url "http://ftpmirror.gnu.org/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2"
-  sha256 "5f835b04b5f7dd4f4d2dc96190ec1621b8d89f2dc6f638f9f8bc1b1014ba8cad"
+  url "http://ftpmirror.gnu.org/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
+  sha256 "b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db"
 
-  bottle do
-    root_url "https://icg.tugraz.at/~skiba/homebrew"
-    sha256 "0f69e18bf5dcd7930efb88925c112f02bf3ee12e93bbdcc5a70a5fd29308853e" => :el_capitan
-  end
+#  bottle do
+#    root_url "https://icg.tugraz.at/~skiba/homebrew"
+#    sha256 "0f69e18bf5dcd7930efb88925c112f02bf3ee12e93bbdcc5a70a5fd29308853e" => :el_capitan
+#  end
 
   def arch
     if Hardware::CPU.type == :intel


### PR DESCRIPTION
The previous version did not build/run on a up-to-date version
of El Captitan and homebrew due to some library version issues
(libisl.dylib)

**Note**: You need to update the bottle-sections of both formulas, for the moment I just commented them out.
